### PR TITLE
fix(crudx): export CrudBaseInterceptor from package root

### DIFF
--- a/packages/crudx/src/interceptors/index.ts
+++ b/packages/crudx/src/interceptors/index.ts
@@ -1,2 +1,3 @@
+export * from "./crud-base.interceptor";
 export * from "./crud-request.interceptor";
 export * from "./crud-response.interceptor";


### PR DESCRIPTION
## Summary

Closes #12.

`packages/crudx/src/interceptors/index.ts` re-exported `crud-request` and `crud-response` but **not** `crud-base`, so `CrudBaseInterceptor` was unreachable from the package root. Consumers were forced into the fragile deep import:

```ts
import { CrudBaseInterceptor } from '@2amtech/crudx/src/interceptors/crud-base.interceptor';
```

This adds the missing re-export so it works from the root, matching its siblings:

```ts
import { CrudBaseInterceptor } from '@2amtech/crudx';
```

## Why CrudBaseInterceptor specifically (not CrudRequestInterceptor)

`CrudBaseInterceptor` is the intended base for interceptors that only need `getCrudInfo()` and provide their **own** `intercept()`. It is **not** substitutable by the already-exported `CrudRequestInterceptor`: that class declares a concrete `intercept(context, next): Observable<any>`, so a consumer with an **async** interceptor (`async intercept(...): Promise<Observable<R>>`) cannot extend it — TypeScript rejects the override (`TS2416`, return type can't widen to a `Promise`). `CrudBaseInterceptor` has no `intercept`, leaving the method free.

## Change

One line in the interceptors barrel:
```ts
export * from "./crud-base.interceptor";   // added
export * from "./crud-request.interceptor";
export * from "./crud-response.interceptor";
```

## Context

Surfaced while migrating **2am.to** off `@dataui/crud` to `@2amtech/crudx` (NestJS 11). Its `relationships-normalizer.interceptor.ts` extends `CrudBaseInterceptor`; once this ships, that file drops the `/src/...` deep import for a clean root import.

## Test plan
- [x] `CrudBaseInterceptor` is exported from `crud-base.interceptor.ts` and now re-exported via the barrel → reachable from the package root
- [ ] CI build (`nx run-many -t build-npm`) green