### PR TITLE
release 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@2amtech/nest-kit",
   "author": "2am.tech",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/2amigos/nest-kit"

--- a/packages/crudx-swagger/package.json
+++ b/packages/crudx-swagger/package.json
@@ -15,7 +15,7 @@
     }
   ],
   "description": "NestJs package to apply swagger meta-data into routes generated with @2amtech/crudx package",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "dependencies": {
     "tslib": "^2.3.0",
     "@2amtech/crudx": "1.0.0",

--- a/packages/crudx/package.json
+++ b/packages/crudx/package.json
@@ -15,7 +15,7 @@
     }
   ],
   "description": "NestJs CRUD for RESTful APIs - request query builder",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "dependencies": {
     "tslib": "^2.3.0",
     "@nestjs/common": "^10.4.15",


### PR DESCRIPTION
Bumps `@2amtech/nest-kit`, `@2amtech/crudx`, and `@2amtech/crudx-swagger` from **1.0.4 → 1.0.5** (version-only; matches the prior `release 1.0.4` flow).

## What's Changed since 1.0.4
- **fix(crudx): export `CrudBaseInterceptor` from package root** (#13) — the one API change; needed by downstream consumers (e.g. 2am.to).
- Security dependency upgrades + CI, docker-compose, and test fixes (maintenance, direct to `main`).

**Full Changelog**: https://github.com/2amigos/nest-kit/compare/1.0.4...1.0.5

## Release mechanics
Merging this does **not** publish. Once merged, a `1.0.5` tag + GitHub Release will be cut; `npm_deploy.yml` (on `release: published`) then publishes `@2amtech/crudx@1.0.5` and `@2amtech/crudx-swagger@1.0.5` to npm.

## FYI (not changed here)
`@2amtech/crudx-swagger` pins `@2amtech/crudx` at exact `1.0.0` (unchanged since before 1.0.4), so it won't pull the 1.0.5 `crudx`. Left as-is to keep this release version-only — happy to fix in a follow-up if intended.